### PR TITLE
Added horizontal support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ xcshareddata
 # Carthage/Checkouts
 
 Carthage/Build
+
+# Other
+#
+
+.DS_Store

--- a/ReorderStackView/APRedorderableStackView.swift
+++ b/ReorderStackView/APRedorderableStackView.swift
@@ -17,6 +17,10 @@ public protocol APStackViewReorderDelegate {
     /// was up or down, as well as what the max and min Y values are of the subview
     @objc optional func didDragToReorder(inUpDirection up: Bool, maxY: CGFloat, minY: CGFloat)
     
+    /// Whenever a user drags a subview for a reordering, the delegate is told whether the direction
+    /// was right or left, as well as what the max and min X values are of the subview
+    @objc optional func didDragHorizontalToReorder(inRightDirection right: Bool, maxX: CGFloat, minX: CGFloat)
+    
     /// didReorder - called whenever a subview was reordered (returns the new index)
     
     /// didEndReordering - called when reordering ends
@@ -130,7 +134,7 @@ public class APRedorderableStackView: UIStackView, UIGestureRecognizerDelegate {
                 
                 if midX > self.pointForReordering.x {
                     // Dragging the view right
-                    self.reorderDelegate?.didDragToReorder?(inUpDirection: true, maxY: maxX, minY: minX)
+                    self.reorderDelegate?.didDragHorizontalToReorder?(inRightDirection: true, maxX: maxX, minX: minX)
                     
                     if let nextView = self.getNextViewInStack(usingIndex: index) {
                         if midX > nextView.frame.midX {
@@ -147,7 +151,7 @@ public class APRedorderableStackView: UIStackView, UIGestureRecognizerDelegate {
                     
                 } else {
                     // Dragging the view left
-                    self.reorderDelegate?.didDragToReorder?(inUpDirection: false, maxY: maxX, minY: minX)
+                    self.reorderDelegate?.didDragHorizontalToReorder?(inRightDirection: false, maxX: maxX, minX: minX)
                     
                     if let previousView = self.getPreviousViewInStack(usingIndex: index) {
                         if midX < previousView.frame.midX {

--- a/ReorderStackView/APRedorderableStackView.swift
+++ b/ReorderStackView/APRedorderableStackView.swift
@@ -99,7 +99,11 @@ public class APRedorderableStackView: UIStackView, UIGestureRecognizerDelegate {
             
             self.actualView = gr.view!
             self.originalPosition = gr.location(in: self)
-            self.originalPosition.y -= self.dragHintSpacing
+            if self.axis == .horizontal {
+                self.originalPosition.x -= self.dragHintSpacing
+            } else {
+                self.originalPosition.y -= self.dragHintSpacing
+            }
             self.pointForReordering = self.originalPosition
             self.prepareForReordering()
             
@@ -115,45 +119,92 @@ public class APRedorderableStackView: UIStackView, UIGestureRecognizerDelegate {
             self.temporaryView.transform = scale.concatenating(translation)
             self.temporaryViewForShadow.transform = translation
             
-            // Use the midY of the temporaryView to determine the dragging direction, location
-            // maxY and minY are used in the delegate call didDragToReorder
-            let maxY = self.temporaryView.frame.maxY
-            let midY = self.temporaryView.frame.midY
-            let minY = self.temporaryView.frame.minY
-            let index = self.indexOfArrangedSubview(self.actualView)
-            
-            if midY > self.pointForReordering.y {
-                // Dragging the view down
-                self.reorderDelegate?.didDragToReorder?(inUpDirection: false, maxY: maxY, minY: minY)
+            if self.axis == .horizontal {
                 
-                if let nextView = self.getNextViewInStack(usingIndex: index) {
-                    if midY > nextView.frame.midY {
-                        
-                        // Swap the two arranged subviews
-                        UIView.animate(withDuration: 0.2, animations: {
-                            self.insertArrangedSubview(nextView, at: index)
-                            self.insertArrangedSubview(self.actualView, at: index + 1)
-                        })
-                        self.finalReorderFrame = self.actualView.frame
-                        self.pointForReordering.y = self.actualView.frame.midY
+                // Use the midX of the temporaryView to determine the dragging direction, location
+                // maxX and minX are used in the delegate call didDragToReorder
+                let maxX = self.temporaryView.frame.maxX
+                let midX = self.temporaryView.frame.midX
+                let minX = self.temporaryView.frame.minX
+                let index = self.indexOfArrangedSubview(self.actualView)
+                
+                if midX > self.pointForReordering.x {
+                    // Dragging the view right
+                    self.reorderDelegate?.didDragToReorder?(inUpDirection: true, maxY: maxX, minY: minX)
+                    
+                    if let nextView = self.getNextViewInStack(usingIndex: index) {
+                        if midX > nextView.frame.midX {
+                            
+                            // Swap the two arranged subviews
+                            UIView.animate(withDuration: 0.2, animations: {
+                                self.insertArrangedSubview(nextView, at: index)
+                                self.insertArrangedSubview(self.actualView, at: index + 1)
+                            })
+                            self.finalReorderFrame = self.actualView.frame
+                            self.pointForReordering.x = self.actualView.frame.midX
+                        }
+                    }
+                    
+                } else {
+                    // Dragging the view left
+                    self.reorderDelegate?.didDragToReorder?(inUpDirection: false, maxY: maxX, minY: minX)
+                    
+                    if let previousView = self.getPreviousViewInStack(usingIndex: index) {
+                        if midX < previousView.frame.midX {
+                            
+                            // Swap the two arranged subviews
+                            UIView.animate(withDuration: 0.2, animations: {
+                                self.insertArrangedSubview(previousView, at: index)
+                                self.insertArrangedSubview(self.actualView, at: index - 1)
+                            })
+                            self.finalReorderFrame = self.actualView.frame
+                            self.pointForReordering.x = self.actualView.frame.midX
+                            
+                        }
                     }
                 }
-                
             } else {
-                // Dragging the view up
-                self.reorderDelegate?.didDragToReorder?(inUpDirection: true, maxY: maxY, minY: minY)
                 
-                if let previousView = self.getPreviousViewInStack(usingIndex: index) {
-                    if midY < previousView.frame.midY {
-                        
-                        // Swap the two arranged subviews
-                        UIView.animate(withDuration: 0.2, animations: {
-                            self.insertArrangedSubview(previousView, at: index)
-                            self.insertArrangedSubview(self.actualView, at: index - 1)
-                        })
-                        self.finalReorderFrame = self.actualView.frame
-                        self.pointForReordering.y = self.actualView.frame.midY
-                        
+                // Use the midY of the temporaryView to determine the dragging direction, location
+                // maxY and minY are used in the delegate call didDragToReorder
+                let maxY = self.temporaryView.frame.maxY
+                let midY = self.temporaryView.frame.midY
+                let minY = self.temporaryView.frame.minY
+                let index = self.indexOfArrangedSubview(self.actualView)
+                
+                if midY > self.pointForReordering.y {
+                    // Dragging the view down
+                    self.reorderDelegate?.didDragToReorder?(inUpDirection: false, maxY: maxY, minY: minY)
+                    
+                    if let nextView = self.getNextViewInStack(usingIndex: index) {
+                        if midY > nextView.frame.midY {
+                            
+                            // Swap the two arranged subviews
+                            UIView.animate(withDuration: 0.2, animations: {
+                                self.insertArrangedSubview(nextView, at: index)
+                                self.insertArrangedSubview(self.actualView, at: index + 1)
+                            })
+                            self.finalReorderFrame = self.actualView.frame
+                            self.pointForReordering.y = self.actualView.frame.midY
+                        }
+                    }
+                    
+                } else {
+                    // Dragging the view up
+                    self.reorderDelegate?.didDragToReorder?(inUpDirection: true, maxY: maxY, minY: minY)
+                    
+                    if let previousView = self.getPreviousViewInStack(usingIndex: index) {
+                        if midY < previousView.frame.midY {
+                            
+                            // Swap the two arranged subviews
+                            UIView.animate(withDuration: 0.2, animations: {
+                                self.insertArrangedSubview(previousView, at: index)
+                                self.insertArrangedSubview(self.actualView, at: index - 1)
+                            })
+                            self.finalReorderFrame = self.actualView.frame
+                            self.pointForReordering.y = self.actualView.frame.midY
+                            
+                        }
                     }
                 }
             }

--- a/ReorderStackView/ExampleView.swift
+++ b/ReorderStackView/ExampleView.swift
@@ -50,7 +50,7 @@ class ExampleView: UIView {
         self.backgroundColor = .white
         
         // Style Subviews
-        self.rStackView.axis = .horizontal
+        self.rStackView.axis = .vertical
         self.rStackView.distribution = .fillProportionally
         self.rStackView.alignment = .fill
         self.rStackView.clipsToBounds = false

--- a/ReorderStackView/ExampleView.swift
+++ b/ReorderStackView/ExampleView.swift
@@ -50,7 +50,7 @@ class ExampleView: UIView {
         self.backgroundColor = .white
         
         // Style Subviews
-        self.rStackView.axis = .vertical
+        self.rStackView.axis = .horizontal
         self.rStackView.distribution = .fillProportionally
         self.rStackView.alignment = .fill
         self.rStackView.clipsToBounds = false

--- a/ReorderStackView/ExampleViewController.swift
+++ b/ReorderStackView/ExampleViewController.swift
@@ -31,6 +31,10 @@ class ExampleViewController: UIViewController, APStackViewReorderDelegate {
     func didDragToReorder(inUpDirection up: Bool, maxY: CGFloat, minY: CGFloat) {
         print("Dragging: \(up ? "Up" : "Down")")
     }
+    
+    func didDragHorizontalToReorder(inRightDirection right: Bool, maxX: CGFloat, minX: CGFloat) {
+        print("Dragging: \(right ? "Right" : "Left")")
+    }
 
     
     func didEndReordering() {


### PR DESCRIPTION
Here's a new PR that strictly addresses adding horizontal support. I wasn't sure how you want to handle delegation in this case, so currently If the stack view is set up to be horizontal the delegate method (didDragToReorder) is called in the same way where 'up' represents right and 'Y' represents X.