### PR TITLE
add support for use of insertArrangedSubview(view:at)

### DIFF
--- a/ReorderStackView/APRedorderableStackView.swift
+++ b/ReorderStackView/APRedorderableStackView.swift
@@ -68,6 +68,11 @@ public class APRedorderableStackView: UIStackView, UIGestureRecognizerDelegate {
         self.addLongPressGestureRecognizerForReorderingToView(view)
     }
     
+    override public func insertArrangedSubview(_ view: UIView, at stackIndex: Int) {
+        super.insertArrangedSubview(view, at: stackIndex)
+        self.addLongPressGestureRecognizerForReorderingToView(view)
+    }
+    
     fileprivate func addLongPressGestureRecognizerForReorderingToView(_ view: UIView) {
         let longPressGR = UILongPressGestureRecognizer(target: self, action: #selector(APRedorderableStackView.handleLongPress(_:)))
         longPressGR.delegate = self


### PR DESCRIPTION
I broke the reordering in my stackview by switching from `stackview.addArrangedSubview(view)` to `stackview.insertArrangedSubview(view, at: stackIndex)`. It's no problem to support both methods right? 